### PR TITLE
Change duration requirement of ad from 39 seconds to 40, fixes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Spotifree is a free OS X app that automatically detects and mutes Spotify audio 
 	On the first run, **Spotifree** will ask you if you want it to run automatically at login. If you agree, the app will be added to the login items. From this moment, **Spotifree** will mute all **Spotify** ads it detects (all of them, usually). Don't worry though, it will not impact your Mac's performance and you'll never notice it running.
 
 ## How it works
-**Spotifree** is polling Spotify every **.3** seconds to see if current track has **0 popularity** (as all ads do) and is  **less then 40 seconds long** (and all Spotify ads are). If it is, Spotify is muted for a duration of an ad. When an ad is over, the volume is set to the way it was before.
+**Spotifree** is polling Spotify every **.3** seconds to see if current track has **0 popularity** (as all ads do) and is  **40 seconds or less in length** (and all Spotify ads are). If it is, Spotify is muted for a duration of an ad. When an ad is over, the volume is set to the way it was before.
 
 
 

--- a/SpotiFree.applescript
+++ b/SpotiFree.applescript
@@ -90,8 +90,8 @@ on isAnAd()
 	on error
 		return false
 	end try
-	-- If current track's popularity is 0 and its duration is less then 40, then it's almost certainly an ad.
-	if (currentTrackPopularity = 0 and currentTrackDuration < 40) then
+	-- If current track's popularity is 0 and its duration is 40 seconds or less, then it's almost certainly an ad.
+	if (currentTrackPopularity = 0 and currentTrackDuration <= 40) then
 		return true
 	else
 		return false
@@ -154,7 +154,7 @@ on isTheFirstRun()
 		-- We are going to return 'true' even if it was some other error. Not a big deal, after all.
 		return true
 	end try
-	
+
 	if (hasRanBefore ­ "true") then
 		return true
 	else


### PR DESCRIPTION
The culprit of [issue 10](https://github.com/ArtemGordinsky/SpotiFree/issues/10) is [an advertisement exactly 40 seconds in length](https://www.evernote.com/shard/s116/sh/cfc09595-ae7c-44ac-9944-38d3b8cd8adf/27a13013b3c37b7f6fceb8df020403b2). I changed the condition from `< 40` to `<= 40` and the advertisement now mutes.
