### PR TITLE
Correct time displayed in notification

### DIFF
--- a/Spotifree/SpotifyController.m
+++ b/Spotifree/SpotifyController.m
@@ -131,7 +131,7 @@
     [self.spotify play];
 
 	if (self.appData.shouldShowNotifications) {
-        [self displayNotification: [NSString stringWithFormat:@"A Spotify ad was detected! Music will be back in about %ld seconds…", (long)self.spotify.currentTrack.duration]];
+        [self displayNotification: [NSString stringWithFormat:@"A Spotify ad was detected! Music will be back in about %ld seconds…", (long)self.spotify.currentTrack.duration/1000]];
 	}
     
     self.isMuted = YES;


### PR DESCRIPTION
self.spotify.currentTrack.duration is in milliseconds, thus the notification is using the incorrect unit.