### PR TITLE
Delay One Second Before Un-Muting Ad 

### DIFF
--- a/Spotifree.xcodeproj/project.pbxproj
+++ b/Spotifree.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 				TargetAttributes = {
 					944D3A351C32028D00FC3324 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -323,6 +324,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = de.eneas.Spotifree;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -346,6 +348,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = de.eneas.Spotifree;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Spotifree/MenuController.swift
+++ b/Spotifree/MenuController.swift
@@ -22,26 +22,26 @@ class MenuController : NSObject {
     
     func setUpMenu() {
         let statusMenu = NSMenu(title: "Spotifree")
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_INACTIVE", comment: "Spotify state: Inactive"), action: nil, keyEquivalent: "")?.tag = 1
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_INACTIVE", comment: "Spotify state: Inactive"), action: nil, keyEquivalent: "").tag = 1
         statusMenu.addItem(NSMenuItem.separatorItem())
         
         let updateMenu = NSMenu()
-        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_CHECK_FOR_UPDATES", comment:"Menu: Check For Updates..."), action: "checkForUpdates:", keyEquivalent: "")?.target = SUUpdater.sharedUpdater()
+        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_CHECK_FOR_UPDATES", comment:"Menu: Check For Updates..."), action: #selector(SUUpdater.checkForUpdates(_:)), keyEquivalent: "").target = SUUpdater.sharedUpdater()
         updateMenu.addItem(NSMenuItem.separatorItem())
-        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_CHECK_AUTOMATICALLY", comment: "Menu: Check Automatically"), action: "toggleAutomaticallyCheckForUpdates", keyEquivalent: "")!.target = self
-        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_DOWNLOAD_AUTOMATICALLY", comment: "Menu: Download automatically"), action: "toggleAutomaticallyDownloadUpdates", keyEquivalent: "")!.target = self
+        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_CHECK_AUTOMATICALLY", comment: "Menu: Check Automatically"), action: #selector(MenuController.toggleAutomaticallyCheckForUpdates), keyEquivalent: "").target = self
+        updateMenu.addItemWithTitle(NSLocalizedString("MENU_UPDATES_DOWNLOAD_AUTOMATICALLY", comment: "Menu: Download automatically"), action: #selector(MenuController.toggleAutomaticallyDownloadUpdates), keyEquivalent: "").target = self
         let updateItem = NSMenuItem(title:NSLocalizedString("MENU_UPDATES", comment: "Menu: Updates"), action: nil, keyEquivalent: "")
         updateItem.submenu = updateMenu;
         
         statusMenu.addItem(updateItem);
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_HIDE_ICON", comment: "Menu: Hide Icon"), action: "hideIconClicked", keyEquivalent: "")!.target = self
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_HIDE_ICON", comment: "Menu: Hide Icon"), action: #selector(MenuController.hideIconClicked), keyEquivalent: "").target = self
         statusMenu.addItem(NSMenuItem.separatorItem())
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_RUN_AT_LOGIN", comment: "Menu: Run At Login"), action: "toggleLoginItem", keyEquivalent: "")!.target = self
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_NOTIFICATIONS", comment: "Menu: Notifications"), action: "toggleNotifications", keyEquivalent: "")!.target = self
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_RUN_AT_LOGIN", comment: "Menu: Run At Login"), action: #selector(MenuController.toggleLoginItem), keyEquivalent: "").target = self
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_NOTIFICATIONS", comment: "Menu: Notifications"), action: #selector(MenuController.toggleNotifications), keyEquivalent: "").target = self
         statusMenu.addItem(NSMenuItem.separatorItem())
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_DONATE", comment: "Menu: Donate"), action: "donateLinkClicked", keyEquivalent: "")!.target = self
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_ABOUT", comment: "Menu: About"), action: "aboutItemClicked", keyEquivalent: "")!.target = self
-        statusMenu.addItemWithTitle(NSLocalizedString("MENU_QUIT", comment: "Menu: Quit"), action: "terminate:", keyEquivalent: "q")!.keyEquivalentModifierMask = Int(NSEventModifierFlags.CommandKeyMask.rawValue);
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_DONATE", comment: "Menu: Donate"), action: #selector(MenuController.donateLinkClicked), keyEquivalent: "").target = self
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_ABOUT", comment: "Menu: About"), action: #selector(MenuController.aboutItemClicked), keyEquivalent: "").target = self
+        statusMenu.addItemWithTitle(NSLocalizedString("MENU_QUIT", comment: "Menu: Quit"), action: "terminate:", keyEquivalent: "q");
         statusMenu.addItem(NSMenuItem.separatorItem())
         
         statusItem = NSStatusBar.systemStatusBar().statusItemWithLength(NSSquareStatusItemLength)
@@ -51,16 +51,16 @@ class MenuController : NSObject {
     }
     
     override func validateMenuItem(menuItem: NSMenuItem) -> Bool {
-        if menuItem.action == "toggleNotifications" {
+        if menuItem.action == #selector(MenuController.toggleNotifications) {
             menuItem.state = Int(DataManager.sharedData.shouldShowNofifications())
         }
-        if menuItem.action == "toggleLoginItem" {
+        if menuItem.action == #selector(MenuController.toggleLoginItem) {
             menuItem.state = Int(DataManager.sharedData.isInLoginItems())
         }
-        if menuItem.action == "toggleAutomaticallyCheckForUpdates" {
+        if menuItem.action == #selector(MenuController.toggleAutomaticallyCheckForUpdates) {
             menuItem.state = Int(SUUpdater.sharedUpdater().automaticallyChecksForUpdates)
         }
-        if menuItem.action == "toggleAutomaticallyDownloadUpdates" {
+        if menuItem.action == #selector(MenuController.toggleAutomaticallyDownloadUpdates) {
             menuItem.state = Int(SUUpdater.sharedUpdater().automaticallyDownloadsUpdates)
             return SUUpdater.sharedUpdater().automaticallyChecksForUpdates
         }

--- a/Spotifree/SpotifyManager.swift
+++ b/Spotifree/SpotifyManager.swift
@@ -40,7 +40,7 @@ class SpotifyManager: NSObject {
     }
     
     func start() {
-        NSDistributedNotificationCenter.defaultCenter().addObserver(self, selector: "playbackStateChanged:", name: "com.spotify.client.PlaybackStateChanged", object: nil);
+        NSDistributedNotificationCenter.defaultCenter().addObserver(self, selector: #selector(SpotifyManager.playbackStateChanged(_:)), name: "com.spotify.client.PlaybackStateChanged", object: nil);
         
         if NSRunningApplication.runningApplicationsWithBundleIdentifier("com.spotify.client").count != 0 && spotify.playerState! == .Playing {
             startPolling()
@@ -69,7 +69,7 @@ class SpotifyManager: NSObject {
     
     func startPolling() {
         if (timer != nil) {return}
-        timer = NSTimer.scheduledTimerWithTimeInterval(DataManager.sharedData.pollingRate(), target: self, selector: "checkForAd", userInfo: nil, repeats: true)
+        timer = NSTimer.scheduledTimerWithTimeInterval(DataManager.sharedData.pollingRate(), target: self, selector: #selector(SpotifyManager.checkForAd), userInfo: nil, repeats: true)
         timer!.fire()
         
         state = .Active

--- a/Spotifree/SpotifyManager.swift
+++ b/Spotifree/SpotifyManager.swift
@@ -105,8 +105,13 @@ class SpotifyManager: NSObject {
     func unmute() {
         if !isMuted {return}
         
-        isMuted = false
-        spotify.setSoundVolume!(oldVolume)
+        // Delay 1 second to avoid tail end of the advertisement
+        let time = dispatch_time(dispatch_time_t(DISPATCH_TIME_NOW), 1 * Int64(NSEC_PER_SEC))
+        
+        dispatch_after(time, dispatch_get_main_queue()) {
+            self.isMuted = false
+            self.spotify.setSoundVolume!(self.oldVolume)
+        }
     }
     
     func displayNotificationWithText(text : String) {

--- a/Spotifree/SpotifyManager.swift
+++ b/Spotifree/SpotifyManager.swift
@@ -105,8 +105,8 @@ class SpotifyManager: NSObject {
     func unmute() {
         if !isMuted {return}
         
-        // Delay 1 second to avoid tail end of the advertisement
-        let time = dispatch_time(dispatch_time_t(DISPATCH_TIME_NOW), 1 * Int64(NSEC_PER_SEC))
+        // Delay 3/4 second to avoid tail end of the advertisement
+        let time = dispatch_time(dispatch_time_t(DISPATCH_TIME_NOW), (Int64(NSEC_PER_SEC) / 4) * 3)
         
         dispatch_after(time, dispatch_get_main_queue()) {
             self.isMuted = false


### PR DESCRIPTION
This small tweak prevents you from hearing the last second of the advertisement.

EDIT: 3/4 of a second actually works better. The code in the pull request has been updated to reflect this.