### PR TITLE
Skip explicit songs

### DIFF
--- a/Spotifree/DataManager.swift
+++ b/Spotifree/DataManager.swift
@@ -10,6 +10,7 @@ import Cocoa
 
 let KEY_MENU_BAR_ICON_HIDDEN = "SFMenuBarIconHidden"
 let KEY_SHOW_NOTIFICATIONS = "SFShowNotifications"
+let KEY_SKIP_EXPLICIT = "SFSkipExplicit"
 let KEY_POLLING_RATE = "SFPollingRate"
 
 class DataManager : NSObject {
@@ -85,5 +86,15 @@ class DataManager : NSObject {
     
     func shouldShowNofifications() -> Bool {
         return UserDefaults.standard.bool(forKey: KEY_SHOW_NOTIFICATIONS)
+    }
+
+    func toggleSkipExplicitSetting() {
+        let skipExplicit = UserDefaults.standard.bool(forKey: KEY_SKIP_EXPLICIT)
+        UserDefaults.standard.set(!skipExplicit, forKey: KEY_SKIP_EXPLICIT)
+        UserDefaults.standard.synchronize()
+    }
+
+    func shouldSkipExplicit() -> Bool {
+        return UserDefaults.standard.bool(forKey: KEY_SKIP_EXPLICIT)
     }
 }

--- a/Spotifree/Main.storyboard
+++ b/Spotifree/Main.storyboard
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <deployment version="101000" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
     </dependencies>
     <scenes>
         <!--Application-->

--- a/Spotifree/MenuController.swift
+++ b/Spotifree/MenuController.swift
@@ -38,6 +38,7 @@ class MenuController : NSObject {
         statusMenu.addItem(NSMenuItem.separator())
         statusMenu.addItem(withTitle: NSLocalizedString("MENU_RUN_AT_LOGIN", comment: "Menu: Run At Login"), action: #selector(MenuController.toggleLoginItem), keyEquivalent: "").target = self
         statusMenu.addItem(withTitle: NSLocalizedString("MENU_NOTIFICATIONS", comment: "Menu: Notifications"), action: #selector(MenuController.toggleNotifications), keyEquivalent: "").target = self
+        statusMenu.addItem(withTitle: NSLocalizedString("MENU_SKIP_EXPLICIT", comment: "Menu: Skip Explicit Songs"), action: #selector(MenuController.toggleSkipExplicit), keyEquivalent: "").target = self
         statusMenu.addItem(NSMenuItem.separator())
         statusMenu.addItem(withTitle: NSLocalizedString("MENU_DONATE", comment: "Menu: Donate"), action: #selector(MenuController.donateLinkClicked), keyEquivalent: "").target = self
         statusMenu.addItem(withTitle: NSLocalizedString("MENU_ABOUT", comment: "Menu: About"), action: #selector(MenuController.aboutItemClicked), keyEquivalent: "").target = self
@@ -53,6 +54,9 @@ class MenuController : NSObject {
     override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(MenuController.toggleNotifications) {
             menuItem.state = Int(DataManager.sharedData.shouldShowNofifications())
+        }
+        if menuItem.action == #selector(MenuController.toggleSkipExplicit) {
+            menuItem.state = Int(DataManager.sharedData.shouldSkipExplicit())
         }
         if menuItem.action == #selector(MenuController.toggleLoginItem) {
             menuItem.state = Int(DataManager.sharedData.isInLoginItems())
@@ -101,6 +105,10 @@ class MenuController : NSObject {
         setUpMenu()
     }
     
+    func toggleSkipExplicit() {
+        DataManager.sharedData.toggleSkipExplicitSetting()
+    }
+
     func toggleNotifications() {
         DataManager.sharedData.toggleShowNotifications()
     }

--- a/Spotifree/fr.lproj/Localizable.strings
+++ b/Spotifree/fr.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "Notifications";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "Quitter Spotifree";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "Une pub Spotify a été détectée! La musique va revenir dans %i secondes";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "OK";

--- a/Spotifree/hu.lproj/Localizable.strings
+++ b/Spotifree/hu.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "Értesítések";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "Spotifree bezárása";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "Spotify reklám észlelve! A zene folytatódik körülbelül %i másodperc múlva...";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "Rendben";

--- a/Spotifree/it.lproj/Localizable.strings
+++ b/Spotifree/it.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "Notifiche";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "Esci da Spotifree";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "È stata rilevata una pubblicità di Spotify! La musica tornerà tra circa %i secondi…";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "OK";

--- a/Spotifree/ko-KR.lproj/Localizable.strings
+++ b/Spotifree/ko-KR.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "알림";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "프로그램 종료";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "광고가 감지되었습니다! 음악이 약 %i 초 뒤에 다시 시작됩니다...";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "확인";

--- a/Spotifree/nl.lproj/Localizable.strings
+++ b/Spotifree/nl.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "Notificaties";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "Spotifree afsluiten";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "Een Spotify advertentie is gedetecteerd! De muziek zal verder gaan in ongeveer %i seconden...";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "OK";

--- a/Spotifree/pl-PL.lproj/Localizable.strings
+++ b/Spotifree/pl-PL.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 /* Menu: Notifications */
 "MENU_NOTIFICATIONS" = "Powiadomienia";
 
+/* Menu: Skip Explicit Songs */
+"MENU_SKIP_EXPLICIT" = "Skip Explicit Songs";
+
 /* Menu: Quit */
 "MENU_QUIT" = "Zamknij Spotifree";
 
@@ -48,6 +51,9 @@
 
 /* Notification: A Spotify ad was detected! Music will be back in about %i seconds... */
 "NOTIFICATION_AD_DETECTED" = "Reklama Spotify została wykryta! Muzyka zostanie wznowiona w przeciągu %i sekund...";
+
+/* Notification: Skipped explicit song */
+"NOTIFICATION_SKIP_EXPLICIT" = "Skipped explicit song";
 
 /* General: OK */
 "OK" = "OK";


### PR DESCRIPTION
Blocking explicit songs is one of the oldest and most-requested features for Spotify (see https://community.spotify.com/t5/Live-Ideas/Explicit-button/idi-p/3869)

This adds the ability to optionally skip explicit songs to Spotifree.
